### PR TITLE
20260425_00 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-04-25: shared shell help option parsing
+
+## Version 1.0.7 (2026-04-25)
+
+- Added a shared `__helpsys_parse_options` helper in [`bin/shinclude/helpsys_lib.sh`](bin/shinclude/helpsys_lib.sh) for consistent `-h`, `--help`, and `-x` handling across sourced shell functions.
+- Refactored [`bin/shinclude/venv_lib.sh`](bin/shinclude/venv_lib.sh) option parsing to use the shared helper, with internal callbacks for function-specific options such as `lenv` sorting flags and `vpmg` version/preserve flags.
+- Fixed a bug where `vhelp  would complain about
+  ```
+  bash: __VENV_SCRIPTS: bad array subscript
+  ```
+- Even though it's not "ofically " part of this, made an enhancement to `mympy-comp` so it woudl pick up the correct Xcode `/usr/include` and `/usr/lib` when recompiling numpy.
+- Added a new function `vpmg` to `venv_lib.sh` to migrate a virtual environment to a new Python version and preserve the packages.
+
 ## Version 1.0.6 (2025-12-23)
 
 ## 2025-12-23: Error handling improvements, OS/ARCH portability, and installer robustness

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # venvutil - Manage Conda and Pip VENV's with some simple functions and scripts
 
-This is release v1.0.6. This project is continuously evolving, becoming a catch-all for useful tools and shell functions that facilitate working with Python VENV's and LLM's.
+This is release v1.0.7. This project is continuously evolving, becoming a catch-all for useful tools and shell functions that facilitate working with Python VENV's and LLM's.
 
 ## Table of Contents
 

--- a/bin/numpy-comp.sh
+++ b/bin/numpy-comp.sh
@@ -78,5 +78,13 @@ else
     fi
 fi
 
+SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+
+INCLUDE="$SDKROOT/usr/include"
+LIB="$SDKROOT/usr/lib"
+
+CFLADS="-I ${INCLUDE} -I/System/Library/Frameworks/vecLib.framework/Headers"
+LD_FLAGS="${LIB} -L$LIB -framework Accelerate"
+
 echo "Installing NumPy version $VERSION..."
-CFLAGS="-I/System/Library/Frameworks/vecLib.framework/Headers -Wl,-framework -Wl,Accelerate -framework Accelerate" pip install numpy=="$VERSION" --force-reinstall --no-deps --no-cache --no-binary :all: --no-build-isolation --compile -Csetup-args=-Dblas=accelerate -Csetup-args=-Dlapack=accelerate -Csetup-args=-Duse-ilp64=true
+CFLAGS="${CFLADS} ${LD_FLAGS}" pip install numpy=="$VERSION" --force-reinstall --no-deps --no-cache --no-binary :all: --no-build-isolation --compile -Csetup-args=-Dblas=accelerate -Csetup-args=-Dlapack=accelerate -Csetup-args=-Duse-ilp64=true

--- a/bin/shinclude/helpsys_lib.sh
+++ b/bin/shinclude/helpsys_lib.sh
@@ -72,18 +72,15 @@ declare -g -a __VENV_INTERNAL_FUNCTIONS=(
     "docs_base_path"
     "function_description"
     "general_help"
-    "general_help"
     "generate_markdown"
     "get_script_readme_file"
     "get_system_readme_file"
     "help_functions"
-    "init_help_system"
+    "__helpsys_parse_options"
     "init_help_system"
     "process_scripts"
     "script_description"
     "specific_function_help"
-    "specific_function_help"
-    "specific_script_help"
     "specific_script_help"
     "write_function_doc"
     "write_page_footer"
@@ -929,6 +926,92 @@ help_functions() {
 
 }
 
+# # Function: __helpsys_parse_options
+#  `__helpsys_parse_options` - Parse common help/debug options.
+# ## Description
+# - **Purpose**:
+#   - Handles common function options consistently across sourced shell libraries.
+#   - Supports `-h`, `--help`, and `-x`, while allowing callers to process additional
+#     options through an optional callback.
+# - **Usage**:
+#   - `__helpsys_parse_options <optstring> [option_handler] "$@"`
+# - **Scope**:
+#   - Internal
+# - **Input Parameters**:
+#   - `optstring`: The `getopts` option string for the caller.
+#   - `option_handler`: Optional callback for caller-specific options.
+#   - `"$@"`: The caller's original argument list.
+# - **Output**:
+#   - Sets `__helpsys_optind` to the parsed `OPTIND` value.
+#   - Sets `__helpsys_help_requested=true` when help was displayed.
+#   - Sets caller-scoped `set_here=y` when `-x` is used.
+# - **Exceptions**:
+#   - Returns non-zero for invalid options or option-handler failures.
+#
+__helpsys_parse_options() {
+    local optstring="$1"; shift
+    local option_handler="${1:-}"; shift
+    local parse_optstring="${optstring#:}"
+    local opt
+    local OPTIND=1
+    local OPTERR=0
+    local func_name="${FUNCNAME[1]}"
+
+    __helpsys_help_requested=false
+    __helpsys_optind=1
+
+    while getopts ":${parse_optstring}-:" opt "$@"; do
+        case "${opt}" in
+            h)
+                vhelp "${func_name}"
+                __helpsys_help_requested=true
+                __helpsys_optind="${OPTIND}"
+                return 0
+                ;;
+            x)
+                set -x
+                # shellcheck disable=SC2034
+                set_here="y"
+                ;;
+            -)
+                case "${OPTARG}" in
+                    help)
+                        vhelp "${func_name}"
+                        __helpsys_help_requested=true
+                        __helpsys_optind="${OPTIND}"
+                        return 0
+                        ;;
+                    *)
+                        echo "Invalid option: --${OPTARG}" >&2
+                        vhelp "${func_name}"
+                        return 1
+                        ;;
+                esac
+                ;;
+            \?)
+                echo "Invalid option: -${OPTARG}" >&2
+                vhelp "${func_name}"
+                return 1
+                ;;
+            :)
+                echo "Option -${OPTARG} requires an argument." >&2
+                vhelp "${func_name}"
+                return 1
+                ;;
+            *)
+                if [[ -z "${option_handler}" ]] || ! "${option_handler}" "${opt}" "${OPTARG:-}"; then
+                    echo "Invalid option: -${opt}" >&2
+                    vhelp "${func_name}"
+                    return 1
+                fi
+                ;;
+        esac
+    done
+
+    __helpsys_optind="${OPTIND}"
+    return 0
+}
+
 # # Function: vhelp
 #  `vhelp` - Main entry point for the help system.
 # ## Description
@@ -959,7 +1042,7 @@ vhelp() {
     command -v "${MD_PROCESSOR}" > /dev/null 2>&1 && md_command="${MD_PROCESSOR}" || md_command="cat"
 
     # Check if the subcommand is a known script name
-    if [[ -n "${__VENV_SCRIPTS["${subcommand}"]:-""}" ]]; then
+    if [[ -n "${subcommand}" && -n "${__VENV_SCRIPTS["${subcommand}"]:-""}" ]]; then
         is_script=1
     fi
 

--- a/bin/shinclude/venv_lib.sh
+++ b/bin/shinclude/venv_lib.sh
@@ -101,10 +101,29 @@ __VENV_INTERNAL_FUNCTIONS=(
     "push_venv"
     "pop_venv"
     "__set_venv_vars"
+    "__lenv_parse_option"
+    "__vpmg_parse_option"
 )
 
 # Initialize the stack
 declare -ga __VENV_STACK=()
+
+__lenv_parse_option() {
+    case "$1" in
+        t) sort_by_time=true ;;
+        r) sort_opts="-r" ;;
+        l) time_opts="."; sort_key="3"; date_spacing="20" ;;
+        *) return 1 ;;
+    esac
+}
+
+__vpmg_parse_option() {
+    case "$1" in
+        v) version="$2" ;;
+        p) preserve=1 ;;
+        *) return 1 ;;
+    esac
+}
 
 
 # # Function: push_venv
@@ -294,16 +313,10 @@ vdsc() {
 #   - Errors if the environment does not exist.
 #
 cact() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local new_env="$1"
 
@@ -359,16 +372,10 @@ cact() {
 #   - None
 #
 dact() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local stack_value
 
@@ -418,17 +425,10 @@ dact() {
 #   - Errors if no previous environment exists.
 #
 pact() {
-    local OPTIND=1
-
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     pop_venv
     local previous_env="${__sv__}"
@@ -480,20 +480,10 @@ lenv() {
     local time_opts=" "
     local sort_key="3"
     local date_spacing="11"
-    local OPTIND=1
-
-    # Parse options
-    while getopts "ltrhx" opt; do
-        case $opt in
-            t) sort_by_time=true ;;
-            r) sort_opts="-r" ;;
-            l) time_opts="."; sort_key="3"; date_spacing="20";;
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "ltrhx" "__lenv_parse_option" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     # Get environment info excluding comments
     local envs_info
@@ -618,16 +608,10 @@ lastenv() {
 #   - Errors during environment creation are handled by conda.
 #
 benv() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     # Check for environment name
     if [ -z "$1" ]; then
@@ -679,19 +663,12 @@ benv() {
 #   - Errors during environment creation are handled by conda.
 #
 nenv() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local prefix="$1"; shift
-    local extra_options="$*"
 
     [ -z "${prefix}" ] && {
         echo "Error: Prefix is required." >&2
@@ -729,16 +706,10 @@ nenv() {
 #   - Errors if the environment does not exist.
 #
 denv() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local env_to_delete="$1"
 
@@ -774,16 +745,10 @@ denv() {
 #   - Errors during deactivation or deletion are handled by conda.
 #
 renv() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local env_to_delete=${CONDA_DEFAULT_ENV}
     local previous_env=${__VENV_PREV}
@@ -829,16 +794,10 @@ renv() {
 #   - Errors if the source environment does not exist.
 #
 ccln() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     # Check if current environment exists
     if [ -z "${CONDA_DEFAULT_ENV}" ]; then
@@ -900,16 +859,10 @@ ccln() {
 #   - Errors if the environment does not exist.
 #
 vren() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local old_name new_name
 
@@ -973,6 +926,90 @@ vren() {
     return ${__rc__}
 }
 
+# # Function: vpmg
+# `vpmg` - Migrate the active virtual environment to a different Python version.
+#
+# ## Description
+# - **Purpose**:
+#   - Rebuilds the currently active conda virtual environment with a requested Python version.
+#   - Captures the installed pip package names, renames the current environment to a backup name,
+#     recreates the original environment with the requested Python version, and reinstalls the
+#     captured packages into the rebuilt environment.
+#   - By default, removes the backup environment after the migration succeeds.
+# - **Usage**:
+#   - `vpmg -v VERSION [-p]`
+# - **Options**:
+#   - `-v VERSION`  Python version to install in the rebuilt environment, such as `3.12`.
+#   - `-p`          Preserve the backup environment after a successful migration.
+#   - `-h`          Show this help message.
+#   - `-x`          Enable debug mode.
+# - **Input Parameters**:
+#   - None. The command operates on the currently active conda environment.
+# - **Output**:
+#   - Recreates the active environment with the requested Python version and reinstalls pip packages.
+#   - Creates a temporary backup environment named `<current_env>_bak` during the migration.
+# - **Exceptions**:
+#   - Returns `EINVAL` if no conda environment is active or no Python version is supplied.
+#   - Restores the backup environment name if environment creation or package installation fails.
+#
+vpmg() {
+    local version=""
+    local preserve=0
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hv:px" "__vpmg_parse_option" "$@" || return "$(errno_warn $?)"
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
+
+    [[ -n "${CONDA_DEFAULT_ENV:-}" ]] || return "$(errno_warn 22)"
+    [[ -n "$version" ]] || return "$(errno_warn 22)"
+
+    local orig_env="${CONDA_DEFAULT_ENV}"
+    local backup_env="${orig_env}_bak"
+    local freeze_file pkgs
+
+    # Capture package names BEFORE we switch envs.
+    # - Drop first 2 header lines, take col 1
+    # mapfile -t pkgs < <(pip list | sed -n '3,${s/[[:space:]].*//;p;}')
+    freeze_file="${VENVUTIL_CONFIG}/freeze/${CONDA_DEFAULT_ENV}.current.txt"
+
+
+freeze_file="${VENVUTIL_CONFIG}/freeze/${CONDA_DEFAULT_ENV}.current.txt"
+
+    mapfile -t pkgs < <(
+        sed -E '
+            s/^([^ ]+) @ (git\+[^ ]+)/\2/;   # pkg @ git+... → git+...
+            s/@[a-f0-9]{40}//;              # strip commit hashes
+            s/==.*$//;                      # remove version pins
+        ' "$freeze_file"
+    )
+
+    # Rename current env out of the way (vren activates backup env)
+    vren "$backup_env" || return "$(errno_warn $?)"
+
+    # Create the new env with requested Python (benv activates orig_env)
+    benv "$orig_env" "python=${version}" || {
+        __rc__=$?
+        vren "$orig_env" >/dev/null 2>&1
+        return "$(errno_warn ${__rc__})"
+    }
+
+    # Install prior packages into the new env
+    # (single command, logged by your wrapper)
+    echo "pip install ${pkgs[@]}"
+    pip install ${pkgs[@]} || {
+        __rc__=$?
+        cact "${backup_env}"
+        denv "${orig_env}"
+        vren "$orig_env" >/dev/null 2>&1
+        return "$(errno_warn ${__rc__})"
+    }
+
+    (( preserve )) && return 0
+    denv "$backup_env" || return "$(errno_warn $?)"
+
+    return "${__rc__}"
+}
+
 # # Function: venvdiff
 # `venvdiff` - Compare Two Virtual Environments.
 #
@@ -993,16 +1030,10 @@ vren() {
 #   - Errors if either environment does not exist.
 #
 vdiff() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     # Check that two arguments are provided
     if [ "$#" -ne 2 ]; then

--- a/docs/shdoc/README.md
+++ b/docs/shdoc/README.md
@@ -33,4 +33,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:34
+Generated on: 2026-04-25 at 12:54:18

--- a/docs/shdoc/bin/shinclude/config_lib_sh.md
+++ b/docs/shdoc/bin/shinclude/config_lib_sh.md
@@ -30,4 +30,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/errno_lib_sh.md
+++ b/docs/shdoc/bin/shinclude/errno_lib_sh.md
@@ -32,4 +32,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/__helpsys_parse_options.md
+++ b/docs/shdoc/bin/shinclude/functions/__helpsys_parse_options.md
@@ -1,0 +1,35 @@
+## __helpsys_parse_options
+# Function: __helpsys_parse_options
+ `__helpsys_parse_options` - Parse common help/debug options.
+## Description
+- **Purpose**:
+  - Handles common function options consistently across sourced shell libraries.
+  - Supports `-h`, `--help`, and `-x`, while allowing callers to process additional
+    options through an optional callback.
+- **Usage**:
+  - `__helpsys_parse_options <optstring> [option_handler] "$@"`
+- **Scope**:
+  - Internal
+- **Input Parameters**:
+  - `optstring`: The `getopts` option string for the caller.
+  - `option_handler`: Optional callback for caller-specific options.
+  - `"$@"`: The caller's original argument list.
+- **Output**:
+  - Sets `__helpsys_optind` to the parsed `OPTIND` value.
+  - Sets `__helpsys_help_requested=true` when help was displayed.
+  - Sets caller-scoped `set_here=y` when `-x` is used.
+- **Exceptions**:
+  - Returns non-zero for invalid options or option-handler failures.
+
+## Defined in Script
+
+* [helpsys_lib.sh](../helpsys_lib_sh.md)
+Website: [unixwzrd.ai](https://unixwzrd.ai)
+Github Repo: [venvutil](https://github.com/unixwzrd/venvutil)
+Copyright (c) 2025 Michael Sullivan
+Apache License, Version 2.0
+
+---
+
+Generated Markdown Documentation
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/__lenv_parse_option.md
+++ b/docs/shdoc/bin/shinclude/functions/__lenv_parse_option.md
@@ -1,8 +1,8 @@
-## log_message
+## __lenv_parse_option
 
 ## Defined in Script
 
-* [errno_lib.sh](../errno_lib_sh.md)
+* [venv_lib.sh](../venv_lib_sh.md)
 Website: [unixwzrd.ai](https://unixwzrd.ai)
 Github Repo: [venvutil](https://github.com/unixwzrd/venvutil)
 Copyright (c) 2025 Michael Sullivan
@@ -11,4 +11,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2026-04-25 at 12:54:16
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/__set_venv_vars.md
+++ b/docs/shdoc/bin/shinclude/functions/__set_venv_vars.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/__venv_conda_check.md
+++ b/docs/shdoc/bin/shinclude/functions/__venv_conda_check.md
@@ -25,4 +25,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:34
+Generated on: 2026-04-25 at 12:54:18

--- a/docs/shdoc/bin/shinclude/functions/__vpmg_parse_option.md
+++ b/docs/shdoc/bin/shinclude/functions/__vpmg_parse_option.md
@@ -1,8 +1,8 @@
-## log_message
+## __vpmg_parse_option
 
 ## Defined in Script
 
-* [errno_lib.sh](../errno_lib_sh.md)
+* [venv_lib.sh](../venv_lib_sh.md)
 Website: [unixwzrd.ai](https://unixwzrd.ai)
 Github Repo: [venvutil](https://github.com/unixwzrd/venvutil)
 Copyright (c) 2025 Michael Sullivan
@@ -11,4 +11,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2026-04-25 at 12:54:16
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/_deprecated.md
+++ b/docs/shdoc/bin/shinclude/functions/_deprecated.md
@@ -22,4 +22,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/_errno_fallback_lookup.md
+++ b/docs/shdoc/bin/shinclude/functions/_errno_fallback_lookup.md
@@ -13,4 +13,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/_source_check.md
+++ b/docs/shdoc/bin/shinclude/functions/_source_check.md
@@ -11,4 +11,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/benv.md
+++ b/docs/shdoc/bin/shinclude/functions/benv.md
@@ -34,4 +34,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/cact.md
+++ b/docs/shdoc/bin/shinclude/functions/cact.md
@@ -27,4 +27,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/ccln.md
+++ b/docs/shdoc/bin/shinclude/functions/ccln.md
@@ -30,4 +30,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/check_directory.md
+++ b/docs/shdoc/bin/shinclude/functions/check_directory.md
@@ -16,4 +16,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:31
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/check_lib.md
+++ b/docs/shdoc/bin/shinclude/functions/check_lib.md
@@ -25,4 +25,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/colortext.md
+++ b/docs/shdoc/bin/shinclude/functions/colortext.md
@@ -27,4 +27,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/dact.md
+++ b/docs/shdoc/bin/shinclude/functions/dact.md
@@ -27,4 +27,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/denv.md
+++ b/docs/shdoc/bin/shinclude/functions/denv.md
@@ -27,4 +27,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/do_wrapper.md
+++ b/docs/shdoc/bin/shinclude/functions/do_wrapper.md
@@ -25,4 +25,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:34
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/docs_base_path.md
+++ b/docs/shdoc/bin/shinclude/functions/docs_base_path.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/dump_config.md
+++ b/docs/shdoc/bin/shinclude/functions/dump_config.md
@@ -43,4 +43,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:31
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/errfind.md
+++ b/docs/shdoc/bin/shinclude/functions/errfind.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/errno.md
+++ b/docs/shdoc/bin/shinclude/functions/errno.md
@@ -11,4 +11,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/errno_exit.md
+++ b/docs/shdoc/bin/shinclude/functions/errno_exit.md
@@ -33,4 +33,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/errno_warn.md
+++ b/docs/shdoc/bin/shinclude/functions/errno_warn.md
@@ -33,4 +33,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/errval.md
+++ b/docs/shdoc/bin/shinclude/functions/errval.md
@@ -32,4 +32,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/escape_string.md
+++ b/docs/shdoc/bin/shinclude/functions/escape_string.md
@@ -25,4 +25,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/expand_variable.md
+++ b/docs/shdoc/bin/shinclude/functions/expand_variable.md
@@ -22,4 +22,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:31
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/function_description.md
+++ b/docs/shdoc/bin/shinclude/functions/function_description.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/general_help.md
+++ b/docs/shdoc/bin/shinclude/functions/general_help.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/generate_markdown.md
+++ b/docs/shdoc/bin/shinclude/functions/generate_markdown.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/get_function_hash.md
+++ b/docs/shdoc/bin/shinclude/functions/get_function_hash.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:34
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/get_script_readme_file.md
+++ b/docs/shdoc/bin/shinclude/functions/get_script_readme_file.md
@@ -25,4 +25,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/get_system_readme_file.md
+++ b/docs/shdoc/bin/shinclude/functions/get_system_readme_file.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/get_venv_name_from_args.md
+++ b/docs/shdoc/bin/shinclude/functions/get_venv_name_from_args.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:34
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/handle_variable.md
+++ b/docs/shdoc/bin/shinclude/functions/handle_variable.md
@@ -32,4 +32,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/help_functions.md
+++ b/docs/shdoc/bin/shinclude/functions/help_functions.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/help_scripts.md
+++ b/docs/shdoc/bin/shinclude/functions/help_scripts.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/init_help_system.md
+++ b/docs/shdoc/bin/shinclude/functions/init_help_system.md
@@ -27,4 +27,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/lastenv.md
+++ b/docs/shdoc/bin/shinclude/functions/lastenv.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/lenv.md
+++ b/docs/shdoc/bin/shinclude/functions/lenv.md
@@ -38,4 +38,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/load_config.md
+++ b/docs/shdoc/bin/shinclude/functions/load_config.md
@@ -58,4 +58,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:31
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/nenv.md
+++ b/docs/shdoc/bin/shinclude/functions/nenv.md
@@ -28,4 +28,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/next_step.md
+++ b/docs/shdoc/bin/shinclude/functions/next_step.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/pact.md
+++ b/docs/shdoc/bin/shinclude/functions/pact.md
@@ -27,4 +27,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/parse_manifest_metadata.md
+++ b/docs/shdoc/bin/shinclude/functions/parse_manifest_metadata.md
@@ -21,4 +21,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:31
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/pip.md
+++ b/docs/shdoc/bin/shinclude/functions/pip.md
@@ -25,4 +25,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:34
+Generated on: 2026-04-25 at 12:54:18

--- a/docs/shdoc/bin/shinclude/functions/pkg_config_vars.md
+++ b/docs/shdoc/bin/shinclude/functions/pkg_config_vars.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:31
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/pop_stack.md
+++ b/docs/shdoc/bin/shinclude/functions/pop_stack.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/pop_venv.md
+++ b/docs/shdoc/bin/shinclude/functions/pop_venv.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/process_scripts.md
+++ b/docs/shdoc/bin/shinclude/functions/process_scripts.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/ptree.md
+++ b/docs/shdoc/bin/shinclude/functions/ptree.md
@@ -27,4 +27,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/push_stack.md
+++ b/docs/shdoc/bin/shinclude/functions/push_stack.md
@@ -27,4 +27,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/push_venv.md
+++ b/docs/shdoc/bin/shinclude/functions/push_venv.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/remove_duplicates.md
+++ b/docs/shdoc/bin/shinclude/functions/remove_duplicates.md
@@ -20,4 +20,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/renv.md
+++ b/docs/shdoc/bin/shinclude/functions/renv.md
@@ -27,4 +27,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/sanitize.md
+++ b/docs/shdoc/bin/shinclude/functions/sanitize.md
@@ -28,4 +28,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/script_description.md
+++ b/docs/shdoc/bin/shinclude/functions/script_description.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/set_debug.md
+++ b/docs/shdoc/bin/shinclude/functions/set_debug.md
@@ -27,4 +27,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/set_variable.md
+++ b/docs/shdoc/bin/shinclude/functions/set_variable.md
@@ -28,4 +28,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/snum.md
+++ b/docs/shdoc/bin/shinclude/functions/snum.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/sort_2d_array.md
+++ b/docs/shdoc/bin/shinclude/functions/sort_2d_array.md
@@ -35,4 +35,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/source_lib.md
+++ b/docs/shdoc/bin/shinclude/functions/source_lib.md
@@ -34,4 +34,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/specific_function_help.md
+++ b/docs/shdoc/bin/shinclude/functions/specific_function_help.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/specific_script_help.md
+++ b/docs/shdoc/bin/shinclude/functions/specific_script_help.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/stack_op.md
+++ b/docs/shdoc/bin/shinclude/functions/stack_op.md
@@ -28,4 +28,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/stringclean.md
+++ b/docs/shdoc/bin/shinclude/functions/stringclean.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/strip_space.md
+++ b/docs/shdoc/bin/shinclude/functions/strip_space.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/to_upper.md
+++ b/docs/shdoc/bin/shinclude/functions/to_upper.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/update_variable.md
+++ b/docs/shdoc/bin/shinclude/functions/update_variable.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/var_type.md
+++ b/docs/shdoc/bin/shinclude/functions/var_type.md
@@ -29,4 +29,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/vdiff.md
+++ b/docs/shdoc/bin/shinclude/functions/vdiff.md
@@ -28,4 +28,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/vdsc.md
+++ b/docs/shdoc/bin/shinclude/functions/vdsc.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/venv_operation_log.md
+++ b/docs/shdoc/bin/shinclude/functions/venv_operation_log.md
@@ -29,4 +29,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:34
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/vhelp.md
+++ b/docs/shdoc/bin/shinclude/functions/vhelp.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/vnum.md
+++ b/docs/shdoc/bin/shinclude/functions/vnum.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/vpfx.md
+++ b/docs/shdoc/bin/shinclude/functions/vpfx.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/vpmg.md
+++ b/docs/shdoc/bin/shinclude/functions/vpmg.md
@@ -1,0 +1,38 @@
+## vpmg
+# Function: vpmg
+`vpmg` - Migrate the active virtual environment to a different Python version.
+## Description
+- **Purpose**:
+  - Rebuilds the currently active conda virtual environment with a requested Python version.
+  - Captures the installed pip package names, renames the current environment to a backup name,
+    recreates the original environment with the requested Python version, and reinstalls the
+    captured packages into the rebuilt environment.
+  - By default, removes the backup environment after the migration succeeds.
+- **Usage**:
+  - `vpmg -v VERSION [-p]`
+- **Options**:
+  - `-v VERSION`  Python version to install in the rebuilt environment, such as `3.12`.
+  - `-p`          Preserve the backup environment after a successful migration.
+  - `-h`          Show this help message.
+  - `-x`          Enable debug mode.
+- **Input Parameters**:
+  - None. The command operates on the currently active conda environment.
+- **Output**:
+  - Recreates the active environment with the requested Python version and reinstalls pip packages.
+  - Creates a temporary backup environment named `<current_env>_bak` during the migration.
+- **Exceptions**:
+  - Returns `EINVAL` if no conda environment is active or no Python version is supplied.
+  - Restores the backup environment name if environment creation or package installation fails.
+
+## Defined in Script
+
+* [venv_lib.sh](../venv_lib_sh.md)
+Website: [unixwzrd.ai](https://unixwzrd.ai)
+Github Repo: [venvutil](https://github.com/unixwzrd/venvutil)
+Copyright (c) 2025 Michael Sullivan
+Apache License, Version 2.0
+
+---
+
+Generated Markdown Documentation
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/vren.md
+++ b/docs/shdoc/bin/shinclude/functions/vren.md
@@ -29,4 +29,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/functions/write_config.md
+++ b/docs/shdoc/bin/shinclude/functions/write_config.md
@@ -45,4 +45,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:31
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/write_function_doc.md
+++ b/docs/shdoc/bin/shinclude/functions/write_function_doc.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/write_page_footer.md
+++ b/docs/shdoc/bin/shinclude/functions/write_page_footer.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/write_script_doc.md
+++ b/docs/shdoc/bin/shinclude/functions/write_script_doc.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/write_script_function_entry.md
+++ b/docs/shdoc/bin/shinclude/functions/write_script_function_entry.md
@@ -25,4 +25,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/write_script_readme_header.md
+++ b/docs/shdoc/bin/shinclude/functions/write_script_readme_header.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/write_system_readme_entry.md
+++ b/docs/shdoc/bin/shinclude/functions/write_system_readme_entry.md
@@ -25,4 +25,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/write_system_readme_header.md
+++ b/docs/shdoc/bin/shinclude/functions/write_system_readme_header.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/write_table_footer.md
+++ b/docs/shdoc/bin/shinclude/functions/write_table_footer.md
@@ -24,4 +24,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/functions/zero_pad.md
+++ b/docs/shdoc/bin/shinclude/functions/zero_pad.md
@@ -28,4 +28,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/helpsys_lib_sh.md
+++ b/docs/shdoc/bin/shinclude/helpsys_lib_sh.md
@@ -27,6 +27,7 @@
 | [specific_script_help](functions/specific_script_help.md) | Provide detailed documentation for a given script. |
 | [specific_function_help](functions/specific_function_help.md) | Provide detailed documentation for a given function. |
 | [help_functions](functions/help_functions.md) | List available functions and how to get their documentation. |
+| [__helpsys_parse_options](functions/__helpsys_parse_options.md) | Parse common help/debug options. |
 | [vhelp](functions/vhelp.md) | Main entry point for the help system. |
 
 ---
@@ -45,4 +46,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/init_lib_sh.md
+++ b/docs/shdoc/bin/shinclude/init_lib_sh.md
@@ -26,4 +26,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/scripts/config_lib.sh.md
+++ b/docs/shdoc/bin/shinclude/scripts/config_lib.sh.md
@@ -59,4 +59,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:31
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/scripts/errno_lib.sh.md
+++ b/docs/shdoc/bin/shinclude/scripts/errno_lib.sh.md
@@ -33,4 +33,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/scripts/helpsys_lib.sh.md
+++ b/docs/shdoc/bin/shinclude/scripts/helpsys_lib.sh.md
@@ -33,4 +33,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/scripts/init_lib.sh.md
+++ b/docs/shdoc/bin/shinclude/scripts/init_lib.sh.md
@@ -41,4 +41,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:16

--- a/docs/shdoc/bin/shinclude/scripts/string_lib.sh.md
+++ b/docs/shdoc/bin/shinclude/scripts/string_lib.sh.md
@@ -32,4 +32,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:32
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/scripts/type_lib.sh.md
+++ b/docs/shdoc/bin/shinclude/scripts/type_lib.sh.md
@@ -30,4 +30,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/scripts/util_lib.sh.md
+++ b/docs/shdoc/bin/shinclude/scripts/util_lib.sh.md
@@ -32,4 +32,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/scripts/venv_lib.sh.md
+++ b/docs/shdoc/bin/shinclude/scripts/venv_lib.sh.md
@@ -77,4 +77,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/scripts/venvutil_lib.sh.md
+++ b/docs/shdoc/bin/shinclude/scripts/venvutil_lib.sh.md
@@ -67,4 +67,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/scripts/wrapper_lib.sh.md
+++ b/docs/shdoc/bin/shinclude/scripts/wrapper_lib.sh.md
@@ -30,4 +30,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/string_lib_sh.md
+++ b/docs/shdoc/bin/shinclude/string_lib_sh.md
@@ -29,4 +29,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/type_lib_sh.md
+++ b/docs/shdoc/bin/shinclude/type_lib_sh.md
@@ -28,4 +28,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/util_lib_sh.md
+++ b/docs/shdoc/bin/shinclude/util_lib_sh.md
@@ -30,4 +30,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/venv_lib_sh.md
+++ b/docs/shdoc/bin/shinclude/venv_lib_sh.md
@@ -6,6 +6,8 @@
 
 | Function | Description |
 |:--|:--|
+| [__lenv_parse_option](functions/__lenv_parse_option.md) | ## Defined in Script |
+| [__vpmg_parse_option](functions/__vpmg_parse_option.md) | ## Defined in Script |
 | [push_venv](functions/push_venv.md) | Specialized push the default VENV onto the stack. |
 | [pop_venv](functions/pop_venv.md) | Specialized pop the VENV off the stack and decrement. |
 | [__set_venv_vars](functions/__set_venv_vars.md) | Sets internal VENV variables. |
@@ -24,6 +26,7 @@
 | [renv](functions/renv.md) | Revert to Previous Virtual Environment. |
 | [ccln](functions/ccln.md) | Clone current Virtual Environment |
 | [vren](functions/vren.md) | Rename a Virtual Environment. |
+| [vpmg](functions/vpmg.md) | Migrate the active virtual environment to a different Python version. |
 | [vdiff](functions/vdiff.md) | Compare Two Virtual Environments. |
 
 ---
@@ -42,4 +45,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/venvutil_lib_sh.md
+++ b/docs/shdoc/bin/shinclude/venvutil_lib_sh.md
@@ -23,4 +23,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:33
+Generated on: 2026-04-25 at 12:54:17

--- a/docs/shdoc/bin/shinclude/wrapper_lib_sh.md
+++ b/docs/shdoc/bin/shinclude/wrapper_lib_sh.md
@@ -29,4 +29,4 @@ Apache License, Version 2.0
 ---
 
 Generated Markdown Documentation
-Generated on: 2025-12-24 at 07:50:34
+Generated on: 2026-04-25 at 12:54:18

--- a/setup/manifest.lst
+++ b/setup/manifest.lst
@@ -1,5 +1,5 @@
 # This file uses pipe-separated fields
-d |  |  | bin | 755 |  |  | 1376 | 
+d |  |  | bin | 755 |  |  | 1344 | 
 d |  |  | conf | 755 |  |  | 352 | 
 d |  |  | docs | 755 |  |  | 800 | 
 d |  |  | modules | 755 |  |  | 128 | 
@@ -7,15 +7,15 @@ d | bin | bin | shinclude | 755 |  |  | 384 |
 d | docs | docs | shdoc | 755 |  |  | 224 | 
 d | docs/shdoc | docs/shdoc | bin | 755 |  |  | 128 | 
 d | docs/shdoc/bin | docs/shdoc/bin | shinclude | 755 |  |  | 480 | 
-d | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | functions | 755 |  |  | 2752 | 
+d | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | functions | 755 |  |  | 2880 | 
 d | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | scripts | 755 |  |  | 384 | 
 f |  |  | LICENSE | 644 |  |  | 11362 | fbb090d446bc51f5b8611e8c59bddf5447f155e2
-f |  |  | README.md | 644 |  |  | 18954 | a0c361afde2741b93d3217cdf7fea88fcc4ad5ab
+f |  |  | README.md | 644 |  |  | 18954 | 171a7160809cfce2920b7e8793227b5230b443e9
 f |  |  | requirements-build.txt | 644 |  |  | 185 | 5befca95d85d0ff6665950e90a120accc77f2dd4
 f |  |  | requirements.txt | 644 |  |  | 193 | 3464773d7b6781d5d4445e5b3cf50f4c4c38053b
 f |  |  | setup.sh | 755 |  |  | 5378 | bd8ff8919da804fcd268b07441d0ec3a3738ca12
 f |  | setup | manifest.lst | 644 |  |  | 4611 | 
-f |  | setup | setup.cf | 644 |  |  | 1171 | 19fc9efaf634512c5a5591526327250daab61e27
+f |  | setup | setup.cf | 644 |  |  | 1171 | bec2e80be3fdc361b0837cb30137097245372ffb
 f | bin | bin | buildvenvs | 755 |  |  | 15033 | f6b06def5460f5a76d338bc3f0e37482b963b0f6
 f | bin | bin | chunkfile.py | 755 |  |  | 10145 | 0a01ef11ecf02df91b1802f346d9578731e9bd19
 f | bin | bin | compare_test | 755 |  |  | 1446 | 2af66cb27d06860e6cfe78574b80aea07a30e322
@@ -26,7 +26,7 @@ f | bin | bin | generate_manifest.sh | 755 |  |  | 7754 | 367555476ffce85fea62dd
 f | bin | bin | genmd | 755 |  |  | 43150 | 880897d3ff4aaf4a34eb4a1e4e7baa5d80c77d84
 f | bin | bin | ld | 755 |  |  | 2697 | 61e28d8e54ae13b00d6c8f7e0cb4e01bc768b798
 f | bin | bin | numpy_torture.py | 755 |  |  | 5006 | b74789f9f4739141bae59d35b7ea1e210ff65b12
-f | bin | bin | numpy-comp.sh | 755 |  |  | 2974 | 5ef698bb06e9be760e7103dcc5d52d3fc92f83f7
+f | bin | bin | numpy-comp.sh | 755 |  |  | 3119 | a38c30c32d1b35283a6154cd4af97e9bddc07a52
 f | bin | bin | numpybench | 755 |  |  | 3937 | ff389a083a1ce3fa2ff1f48bbd206bd178991ed5
 f | bin | bin | numpyprof | 755 |  |  | 1579 | fe821ae6a607ff116a9ae9f9abc8483125cdfcac
 f | bin | bin | numpytime | 755 |  |  | 1423 | 14349c95f754bc9260a2bf6d4a84b1b6f1126336
@@ -46,12 +46,12 @@ f | bin | bin | vinfo | 755 |  |  | 4789 | 9997bdc1649925c2ee46d15235d504d7bba64
 f | bin | bin | warehouse.sh | 755 |  |  | 3211 | 7ef782147dacf52bcdcf6f1cd7464a1fe8b14e11
 f | bin/shinclude | bin/shinclude | config_lib.sh | 755 |  |  | 17281 | 141775eb9fa92934a8f5baf7c6b31c000002133d
 f | bin/shinclude | bin/shinclude | errno_lib.sh | 755 |  |  | 21577 | 032a52e7a1d619ae0d26b801e0b425ec2df2c0a0
-f | bin/shinclude | bin/shinclude | helpsys_lib.sh | 755 |  |  | 33423 | 117c6c7a39f896042d158218e0c4e0ee4ea95e9d
+f | bin/shinclude | bin/shinclude | helpsys_lib.sh | 755 |  |  | 36218 | 05a1e5f40ad83dfd277bda9d333e8bc8c13c7773
 f | bin/shinclude | bin/shinclude | init_lib.sh | 755 |  |  | 6724 | e822fc9d70227ec60804a2946892fb21135ad619
 f | bin/shinclude | bin/shinclude | string_lib.sh | 755 |  |  | 8716 | e878fe04732200d5a6c2daeb15fcc1349337fab9
 f | bin/shinclude | bin/shinclude | type_lib.sh | 755 |  |  | 10369 | b9387d6c4b556d71de0130f26ac350b1a53d62da
 f | bin/shinclude | bin/shinclude | util_lib.sh | 755 |  |  | 12627 | 29ffe800c02b0486225f12cd79e9eb2f5e16a14a
-f | bin/shinclude | bin/shinclude | venv_lib.sh | 755 |  |  | 30367 | 9a96d837b738917439becf2d5639261a1b4de300
+f | bin/shinclude | bin/shinclude | venv_lib.sh | 755 |  |  | 32654 | d248f5aedcae22b3300f1b1a2e814b4d09031ee9
 f | bin/shinclude | bin/shinclude | venvutil_lib.sh | 755 |  |  | 3155 | 9a77e8caa2fe8c340b08b5dfe613ecb7464fad18
 f | bin/shinclude | bin/shinclude | wrapper_lib.sh | 755 |  |  | 12724 | 785b3753bace623198a54b4946f2d7f119bbb58d
 f | conf | conf | config-a | 755 |  |  | 10167 | 3b7bbdf007f090ccecba521ef654708ec1e4ec8c
@@ -85,111 +85,115 @@ f | docs | docs | Script_Doc_Templ.md | 644 |  |  | 3185 | 623eabdfb544a4f8cc002
 f | docs | docs | Standards.md | 644 |  |  | 2240 | da44d4a15ef86ac98bdf64f9892e6547bf633b0e
 f | docs | docs | warehouse.md | 644 |  |  | 3039 | c7fe4ad3e74302516dafee83d8dd8cdabaa47886
 f | docs/shdoc | docs/shdoc | AUTO_GENERATED_DO_NOT_MODIFY_OR_PLACE_FILES_HERE | 644 |  |  | 0 | da39a3ee5e6b4b0d3255bfef95601890afd80709
-f | docs/shdoc | docs/shdoc | README.md | 644 |  |  | 1505 | 3406430b13fec3e0775dc649300ea8a0028a7200
-f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | config_lib_sh.md | 644 |  |  | 1244 | 771ed1b2cbea71b72d03cbc32fa98bbf2023e7fa
-f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | errno_lib_sh.md | 644 |  |  | 1393 | 6b2475410e5caf1a726f6340dcd53c4bccc6c6c7
-f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | helpsys_lib_sh.md | 644 |  |  | 2944 | dacff98a25a419e23c6164f859686538ae7283ae
-f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | init_lib_sh.md | 644 |  |  | 789 | 4833ab5bcbf3f239dea14a49adf65117c6672762
-f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | string_lib_sh.md | 644 |  |  | 1112 | 0aeb0873889360c65d597c2b7e4833ba7df33b47
-f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | type_lib_sh.md | 644 |  |  | 1045 | cf5c60c4600db83b2b47fa9e6352bb122e5db901
-f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | util_lib_sh.md | 644 |  |  | 1119 | ea6ec545dbd71a37586c040fec4edd115fe3900a
-f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | venv_lib_sh.md | 644 |  |  | 1979 | 8e87b7a50994e267b0f2b684c13127a96e784c73
-f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | venvutil_lib_sh.md | 644 |  |  | 566 | 049b932be6abbc15cfd063907559e7d9ed67348b
-f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | wrapper_lib_sh.md | 644 |  |  | 1204 | 18941bf4d67c57ee0584837bca1c8c82ecbf257f
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | __set_venv_vars.md | 644 |  |  | 657 | 8447bf094f4ab01764acb40fe4dd286cd92884c6
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | __venv_conda_check.md | 644 |  |  | 826 | 4b1f45af198de53f8fcd8d4dea608ddfa3f008e4
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | _deprecated.md | 644 |  |  | 662 | 33f36f5cc3df4f7f77dba5286185af533ca96d53
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | _errno_fallback_lookup.md | 644 |  |  | 475 | 6fb4af16c8991a58425da500782e1fd0dd07b0f3
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | _source_check.md | 644 |  |  | 321 | b63bfae1baeb43c64e2ab4ccd142b612d9bafb74
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | benv.md | 644 |  |  | 1326 | 06573c4bfe7161292f50b07a43f5948372436183
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | cact.md | 644 |  |  | 795 | 8ee7b0931f9831657256ac0e247bde694680b210
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | ccln.md | 644 |  |  | 1039 | 008c4ca939d4bca37bbe666ebb503ed9abd48d22
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | check_directory.md | 644 |  |  | 475 | 8196228694197b6d56981494b1a9c027da76a023
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | check_lib.md | 644 |  |  | 819 | 11400e9d9685d2ea0a8bd78679eee20d3cc1391a
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | colortext.md | 644 |  |  | 893 | dc14eca78f6ee44bd981e542fa063ba9defc1902
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | dact.md | 644 |  |  | 667 | e1e1a9031fbc1509f57a1098b019184ff8eb436f
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | denv.md | 644 |  |  | 775 | 18c02daa1e805172b7731927c49e8acaccd5671d
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | do_wrapper.md | 644 |  |  | 831 | bda7647721f1247d8222126fd93101f59fbd03ba
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | docs_base_path.md | 644 |  |  | 676 | bea391ecc107f8716e782eafdc33431afa820f7b
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | dump_config.md | 644 |  |  | 1425 | d2cbc1385abbaaa714b95bac304f30fe7acf664a
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | errfind.md | 644 |  |  | 847 | c759e22320723cf2fba52480b8d15ee8b21f4a92
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | errno_exit.md | 644 |  |  | 1276 | 309b13432aac0d037385b68c04a857b000eb9308
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | errno_warn.md | 644 |  |  | 1274 | 885df0656152454691e772a6de44eab7a4bcc378
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | errno.md | 644 |  |  | 315 | ca955cbdec7fb510fc87e5aebf25630975e0b7e5
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | errval.md | 644 |  |  | 1071 | df2314a803b34e7951779d43a03fa447e0a46c61
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | escape_string.md | 644 |  |  | 776 | 1d380b1c24b4af924b416920f04f2fafb4663a12
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | expand_variable.md | 644 |  |  | 747 | 29e4579e23885420ee074f4ca860c53cc81570c4
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | function_description.md | 644 |  |  | 760 | bfc0132cd49e583316d9cec5203f63e5bf0bf6d9
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | general_help.md | 644 |  |  | 689 | fd4ca9a75f66c0adfab336cd48ddcc963f179619
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | generate_markdown.md | 644 |  |  | 745 | dd64e76cf22249d5b91b5acde810c57ed619c068
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | get_function_hash.md | 644 |  |  | 751 | 94d51ce1253aab6688dc036c3471598251279fe3
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | get_script_readme_file.md | 644 |  |  | 835 | ced94be1ee3c575c24b3adc14f954360ccf6ad16
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | get_system_readme_file.md | 644 |  |  | 791 | 63d956f6b731fe8eb8359e0591b54d89c7d21c1c
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | get_venv_name_from_args.md | 644 |  |  | 859 | 80b478d4951cc58af1700d575d71abf3cb10e3e9
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | handle_variable.md | 644 |  |  | 1262 | 5648a1fcb7356877a50f9a11e03587990b30da8c
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | help_functions.md | 644 |  |  | 873 | aa3ba106c6082b3dfc1e5549dfdfd2c27fdfdd84
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | help_scripts.md | 644 |  |  | 656 | 99474d9698e4b06d454b14f83ca5cc42f35cd746
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | init_help_system.md | 644 |  |  | 992 | 3b05dadd7cc94edcb598f7a70e01ee63a4e062c4
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | lastenv.md | 644 |  |  | 704 | 8ccc0d8fea0bc7ce5060c9327d41b0d7ce172b9a
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | lenv.md | 644 |  |  | 1602 | ca102b0a24dd3ef841d78b38852b5b1aa3933b77
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | load_config.md | 644 |  |  | 1982 | 23346e34b2176e79059a6b7c6b89b044ec03a859
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | log_message.md | 644 |  |  | 321 | 9ad6e41a9c86136a3309e362cb95a3c2625cf1df
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | nenv.md | 644 |  |  | 1023 | fcc3dceb5abe25726339918b62ca06e139416e4b
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | next_step.md | 644 |  |  | 959 | 68399b736d9684091a323c975b5a01b5851b3f02
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | pact.md | 644 |  |  | 718 | 1df12293dd1568935991ddff73faadd9b776bf77
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | parse_manifest_metadata.md | 644 |  |  | 760 | 988901c6123882d2ee2cf21f4a74eda2cad32d8f
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | pip.md | 644 |  |  | 762 | afa8bfb694c153313930497fb9b99e0718669b29
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | pkg_config_vars.md | 644 |  |  | 660 | 5dcc051053ab177007c2179394a6cb6df6bd852a
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | pop_stack.md | 644 |  |  | 786 | 4c0577c1d2e2ea3eb67a83ca59e37a4ae302a27c
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | pop_venv.md | 644 |  |  | 662 | 87bc7e66e6d1fa9d572b19e02a3045bd4db6cb1e
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | process_scripts.md | 644 |  |  | 794 | 2bb4ed0715247c6215d9b0fb55cfa9646eabf1bd
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | ptree.md | 644 |  |  | 819 | 4a26d824d5a3857182901e835eac1e08870ef9fc
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | push_stack.md | 644 |  |  | 814 | 23f2a7a55f5a15f2b568ff08cdeca7ce327a5572
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | push_venv.md | 644 |  |  | 659 | cb0203eaca1339dd7bf8f082e8dfd21c4e79d99e
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | remove_duplicates.md | 644 |  |  | 702 | 0abd013a614cd6511c67d0aa63c5eb9d74aa4cdd
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | renv.md | 644 |  |  | 837 | 37ac7525cc9068480f56484e5b080a0217470236
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | sanitize.md | 644 |  |  | 879 | d34959d31ee6f64b9a0c7ff316b78aaf390d689c
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | script_description.md | 644 |  |  | 740 | 0bc38d0b6d6e6deb1e899f2c40d667e1300bcff6
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | set_debug.md | 644 |  |  | 904 | 548dc1826bea7c477d0121bdb57d5e042b813841
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | set_variable.md | 644 |  |  | 1116 | 39d716d716293ea61f4fce49ea03efb45b2d40a9
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | snum.md | 644 |  |  | 666 | f8bd086f778504bf73681532c09fb1edb3f6101f
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | sort_2d_array.md | 644 |  |  | 1325 | ba0187465d1c8d92e239931b0d9142320980cc7a
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | source_lib.md | 644 |  |  | 1383 | 297402b5df25a4e4ca2078e97b27f3c6c5cd642f
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | specific_function_help.md | 644 |  |  | 863 | 816b97c2be1d890a5fb9ea95fa70be7921124457
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | specific_script_help.md | 644 |  |  | 850 | ba0e038589b16d6e057606cb8e69a1de7d8f42a1
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | stack_op.md | 644 |  |  | 952 | 45514131f4dfcf0e2efce3680242934fe0a21771
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | stringclean.md | 644 |  |  | 764 | ac7060474be047ac40981a62dfb9ffa084e43eb2
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | strip_space.md | 644 |  |  | 746 | 2ffe55caa138a9372dfa1efe67e031e810663612
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | to_upper.md | 644 |  |  | 650 | 6b262541411777b7c65430d5a19bb622cbc99177
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | update_variable.md | 644 |  |  | 1024 | b3b1d130eea2f490641965f49e1517901c6001e3
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | var_type.md | 644 |  |  | 835 | facbaa78935132757a72051ef17c786adc986bef
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vdiff.md | 644 |  |  | 877 | 9e54003afc7426b865022efd0fa42e0b1a4afdae
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vdsc.md | 644 |  |  | 632 | a6efea3805780cdd61aa8e2bb8adc9bc2ab782b9
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | venv_operation_log.md | 644 |  |  | 1194 | e20375b25dce5806bdd6218ca207d961c4ae78a2
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vhelp.md | 644 |  |  | 795 | a6ec858898714f0b3fe54a4cfdaf0b4e645f24b7
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vnum.md | 644 |  |  | 625 | acf9ccdd285654f1aee9a767d1774c69418d14f4
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vpfx.md | 644 |  |  | 617 | 8c8b634159ffba3fb6754ec4f2416552aa79b8f0
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vren.md | 644 |  |  | 913 | c573d671831e0dca2cbc944e9640cb7a41a1e254
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_config.md | 644 |  |  | 1466 | 3875f6658efab859e1872076247d0c42063ad3ef
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_function_doc.md | 644 |  |  | 833 | 9938748db5556a8c7269246bec315f56b2ebb208
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_page_footer.md | 644 |  |  | 758 | 31000857c01c175d6ac6a02906850f7ec0b5dda4
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_script_doc.md | 644 |  |  | 917 | d0d35c63427bcf3ec08d85867919279ede26f9b0
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_script_function_entry.md | 644 |  |  | 892 | a6766306bf22810cbb8258f29d467920a26f3391
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_script_readme_header.md | 644 |  |  | 951 | 887ac90fe829853908e3d00d1be50836e0f030de
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_system_readme_entry.md | 644 |  |  | 883 | dff2197e2f6a7f80b1a29b7e1cbd2b11c7e0ad3b
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_system_readme_header.md | 644 |  |  | 784 | 6275e26e9dfc20a53e87ad1252111799cd68e2e6
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_table_footer.md | 644 |  |  | 743 | 25db902641637b560e961c12e4877e4522788617
-f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | zero_pad.md | 644 |  |  | 1037 | 7db6ebebc95052a228cdb69935e4f8a93aa3fe96
-f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | config_lib.sh.md | 644 |  |  | 1888 | 2b6aad0c5081aee9d81e1aa58dc1c2a538fa2ba0
-f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | errno_lib.sh.md | 644 |  |  | 1045 | 8a0d5e0da0ffab3280788a89d4286cc588b9f611
-f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | helpsys_lib.sh.md | 644 |  |  | 1251 | 5bc8d1013cae792d2b2efb40f224a1fe38958041
-f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | init_lib.sh.md | 644 |  |  | 1730 | 3254a73769c94ec31989e29072ce0f2c7ffe4e7b
-f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | string_lib.sh.md | 644 |  |  | 859 | 1429acaeaf94efb33ef1a3b956794e2bbea1ad75
-f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | type_lib.sh.md | 644 |  |  | 901 | 0fa70314604d8aae0a839283805b3098733a0191
-f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | util_lib.sh.md | 644 |  |  | 1411 | 444cb3836c0adbb4cf4be3efdecdaa97b9143291
-f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | venv_lib.sh.md | 644 |  |  | 2903 | c1de9d260b850cfb39bcb8bdd0439b5f51d541bb
-f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | venvutil_lib.sh.md | 644 |  |  | 2031 | 35b9dfbea65c794270e64eb9d19d332bb973e5a6
-f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | wrapper_lib.sh.md | 644 |  |  | 1325 | 6fef8912241192e7e885b6bf29014d8f40476a72
+f | docs/shdoc | docs/shdoc | README.md | 644 |  |  | 1505 | 378297027e47eb48e51a914fd8ec8fde3c9e8149
+f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | config_lib_sh.md | 644 |  |  | 1244 | a1d2b6a390589b4e37a4ae117a4b084f99dc4404
+f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | errno_lib_sh.md | 644 |  |  | 1393 | 92e24be541c0601c0e252f02f591d0dc98d0e86c
+f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | helpsys_lib_sh.md | 644 |  |  | 3047 | 5d5aeb388ed73ac447b1818e347e857be92e898b
+f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | init_lib_sh.md | 644 |  |  | 789 | c045b2349b3a46993cb80bcabab47a0fce7a9ce8
+f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | string_lib_sh.md | 644 |  |  | 1112 | ac35a98539483b206f2f8c7ad38f9467496fe87e
+f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | type_lib_sh.md | 644 |  |  | 1045 | 7a6fe4c9dae1c102658857f7453dcc5a81531855
+f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | util_lib_sh.md | 644 |  |  | 1119 | 8a73d5109d71ba4421b748c4b6d5eb5e25cb4d5f
+f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | venv_lib_sh.md | 644 |  |  | 2247 | 6d94cbfe20758a94a95cb940bfdd6cabc05b580c
+f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | venvutil_lib_sh.md | 644 |  |  | 566 | 791a4bf1450d14991cc8ef81f612b5b8f6d21c9e
+f | docs/shdoc/bin/shinclude | docs/shdoc/bin/shinclude | wrapper_lib_sh.md | 644 |  |  | 1204 | d9aa247cce08b5ce9b2851bff3d6b8ea919c6781
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | __helpsys_parse_options.md | 644 |  |  | 1258 | 43136e0d9b5d64059e4c21ca28cf3f05a0a9abe2
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | __lenv_parse_option.md | 644 |  |  | 327 | a649c4fed1549e47debd9e26082c67c563f2cffd
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | __set_venv_vars.md | 644 |  |  | 657 | e618540666a412ae590fa0af2b993e7c0c0e1382
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | __venv_conda_check.md | 644 |  |  | 826 | e96430a0c38d3e0d9fb37429ee9e6d5c883d2492
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | __vpmg_parse_option.md | 644 |  |  | 327 | 9607140bf54c4ada4e1cfad86f6626ec6bcd591b
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | _deprecated.md | 644 |  |  | 662 | 1c3bcf3421a07fe9ead9d5877b1c490b3843b893
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | _errno_fallback_lookup.md | 644 |  |  | 475 | 48d77129d188bfd93c0d4e86a0e037eb2f2dd4c2
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | _source_check.md | 644 |  |  | 321 | 83cb80c440e2940fafbb6a0c86925394310e452e
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | benv.md | 644 |  |  | 1326 | f577fe5e4333e2feb92e38f6ea9d3fb1554d5511
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | cact.md | 644 |  |  | 795 | 57f86fa6602b900177de14c2c95136f858c99ab6
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | ccln.md | 644 |  |  | 1039 | ab996cc853a1a17b330c83dbd5600bf04eb242dd
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | check_directory.md | 644 |  |  | 475 | 64d5e1f71ebce406df5dab255c78105abecd11cf
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | check_lib.md | 644 |  |  | 819 | 87ff0a314f9750ca45a84129c9561c2fb8ed12b0
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | colortext.md | 644 |  |  | 893 | 75e666041d82b15ecd569a3a681aca0428757bf7
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | dact.md | 644 |  |  | 667 | 2e3aab69a8e36af5474948d8ffd851a7cdbbb4bb
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | denv.md | 644 |  |  | 775 | 6070bbbace4550be3ab6a231e029f92c7b51efc2
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | do_wrapper.md | 644 |  |  | 831 | ceb6ecd7b748885bdb67e1fa6c8a3fe0243dfe29
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | docs_base_path.md | 644 |  |  | 676 | f7de194d55848e5f105113cae3fad752817d8aad
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | dump_config.md | 644 |  |  | 1425 | ba023056e8c3f9ebc2a8d0073f2b3ae4664534e1
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | errfind.md | 644 |  |  | 847 | ea192d028054e0348865cf2eb67d537705e00e37
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | errno_exit.md | 644 |  |  | 1276 | 5906faa75892e113657442609117ed71213d500f
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | errno_warn.md | 644 |  |  | 1274 | c27a256e7d11c2392008fff80be52e65ca11339b
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | errno.md | 644 |  |  | 315 | 22850eeb483c2e6a85092e2ee79de30b4295fbc6
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | errval.md | 644 |  |  | 1071 | cd310dcc31081fd34132b40386ab2677c6d3ca59
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | escape_string.md | 644 |  |  | 776 | cc619c4d807d2784507cb1519987bcfe291f491e
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | expand_variable.md | 644 |  |  | 747 | 7db6e8964bc58f8c22f39bb4cd4a199b27432604
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | function_description.md | 644 |  |  | 760 | 5a9b844ea087c5b0601f0f19613e7db6d8d9d2db
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | general_help.md | 644 |  |  | 689 | b4e82c2aed649981e96c2a0836dcc3cd1212dd9a
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | generate_markdown.md | 644 |  |  | 745 | 8dab9843d6c69f37d74bae0aee4d3b8deff9ed6c
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | get_function_hash.md | 644 |  |  | 751 | fbdfc4c8d221df27f15ff7b606687cd315972040
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | get_script_readme_file.md | 644 |  |  | 835 | 0873509bd872f9851bceb4c951225d30665d2fe5
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | get_system_readme_file.md | 644 |  |  | 791 | 7f1a283154d94260ff0c5d267ece3a4336322511
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | get_venv_name_from_args.md | 644 |  |  | 859 | 3fb312b15505b0a36d12511193643af145e3a263
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | handle_variable.md | 644 |  |  | 1262 | 41b60993fa2c984699479e47bc7c8a26cde075dc
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | help_functions.md | 644 |  |  | 873 | 9eb6814c569f13906a03fdf7cbcad483bd2e2b22
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | help_scripts.md | 644 |  |  | 656 | 36095ebdf24c5e63e0aed42c2763d63b1d7531dd
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | init_help_system.md | 644 |  |  | 992 | cd24fd0ad99939455cb50b06f366dd11eb6bfffd
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | lastenv.md | 644 |  |  | 704 | 10fa1d786aa9b803cfbf57e2dca4ff8d5944d888
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | lenv.md | 644 |  |  | 1602 | dbb45faf6d0d12ca957f005dc04c6f527a20c5a5
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | load_config.md | 644 |  |  | 1982 | 6c827ea7f20b9efb1d58f989a28e8ee7a41765fe
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | log_message.md | 644 |  |  | 321 | d73d2d95323c0018d29c092bf323d4c073cbcebe
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | nenv.md | 644 |  |  | 1023 | 4e84b8531b36a831068b0885063bbc259a0eeee0
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | next_step.md | 644 |  |  | 959 | f35e560edcee5afe016adffb8661ee3122b48b49
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | pact.md | 644 |  |  | 718 | df806814c689bd9fd25230e16a869354b2bc1de3
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | parse_manifest_metadata.md | 644 |  |  | 760 | a1722f477215dc8f41be438052139d5106a6a27f
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | pip.md | 644 |  |  | 762 | 5cce2369245002b39a8a5c76d137cf8c3d533105
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | pkg_config_vars.md | 644 |  |  | 660 | c599f48beee1631e3368cc0535fba707db362d64
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | pop_stack.md | 644 |  |  | 786 | 310ccab2f913ca07b392be092f01497b34d21373
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | pop_venv.md | 644 |  |  | 662 | d328f8debd7fbec263e6cfc889d27742f61f163e
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | process_scripts.md | 644 |  |  | 794 | aea910c6d695c9a4560ff24cacf814bf7e11adfc
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | ptree.md | 644 |  |  | 819 | ae4f93a5c5b1c83e33df22dca70bbc60ef19ca2d
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | push_stack.md | 644 |  |  | 814 | 355adbef5e7f8befaf9b1f92ad069e4ffc926372
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | push_venv.md | 644 |  |  | 659 | 52e9976a72d432aa2a703dbc4d3e4970204ff856
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | remove_duplicates.md | 644 |  |  | 702 | 084bea959404c3c0873b492f8f5db41c1064afd7
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | renv.md | 644 |  |  | 837 | eecd4ac7d50a3b3374f4d4aad336e470f4a7de7c
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | sanitize.md | 644 |  |  | 879 | 54ac9e4f24e35278e50e6d288a60a17e4502f8b2
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | script_description.md | 644 |  |  | 740 | 5cc0f50df3df0bc92feb8b7a210d248a146b286e
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | set_debug.md | 644 |  |  | 904 | 92607247e761e7863b772e491166eb9f27247df1
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | set_variable.md | 644 |  |  | 1116 | bc06e6e2175c878d5a26e3e5af4f7a5309c4b1f0
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | snum.md | 644 |  |  | 666 | 9b4d281aa19f68714d5eeedbad1cbd50f3e00a67
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | sort_2d_array.md | 644 |  |  | 1325 | 20f71cdfa61a08e217964a46accda84df5ff7ef1
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | source_lib.md | 644 |  |  | 1383 | bf46484581d075399468c25a7c9f779faa0f0e11
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | specific_function_help.md | 644 |  |  | 863 | dfc3709402b46e554ebbc23b376b393fd53b194b
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | specific_script_help.md | 644 |  |  | 850 | cc0347d1ddae2191257f9f1c74b8b69325832222
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | stack_op.md | 644 |  |  | 952 | 8dbf7a5cbbccdd37e69beaee285e475796c5209a
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | stringclean.md | 644 |  |  | 764 | 8f83e536da938645fe7d7e6db48070fb04afb80b
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | strip_space.md | 644 |  |  | 746 | 693439410bd29cf30feba75ae8e0748e097a0fee
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | to_upper.md | 644 |  |  | 650 | 608c64e35bf719e8c37ac7758ee6c1cc3ca7fcf4
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | update_variable.md | 644 |  |  | 1024 | efcf599c14f83f48b2755333f3f7c41bc4bca801
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | var_type.md | 644 |  |  | 835 | 649288eafb5bbf1d3dc6f638ec1598bd43980f39
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vdiff.md | 644 |  |  | 877 | b0c5971b2cef1953d20d6bb5b2429322a4ce61b3
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vdsc.md | 644 |  |  | 632 | fd91688ca05f465b05d9874166540db0b87ebb87
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | venv_operation_log.md | 644 |  |  | 1194 | 166e6a5fa960691cd3d82c33c0ba31e7e1a15a22
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vhelp.md | 644 |  |  | 795 | 96880da650684f95130352f63677e007257ae7f4
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vnum.md | 644 |  |  | 625 | 74fa76d744771df354fa62b1029a30549379079a
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vpfx.md | 644 |  |  | 617 | 9d6d39d07ba73c06d2db3e3fe63f78a101360e3c
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vpmg.md | 644 |  |  | 1657 | 3c7af705bca581321c13bc767e4450a8e3f33bcb
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | vren.md | 644 |  |  | 913 | 2dd852c2b97ef6b482ea69f02422e329dce6efb4
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_config.md | 644 |  |  | 1466 | d71a87652a265c946c8127a7f22732124699bc03
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_function_doc.md | 644 |  |  | 833 | 7c937d888338229cdfbc941c16dccf6d5a486ab7
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_page_footer.md | 644 |  |  | 758 | 7bd073f5a63d95322941ee85eb8e9a9d2dd0dd6b
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_script_doc.md | 644 |  |  | 917 | 9db233ac90e2d924d42dafd8b4d7142c3f0fa59a
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_script_function_entry.md | 644 |  |  | 892 | fc5395c804745b7ca4e62992b6403e6fe11a7a46
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_script_readme_header.md | 644 |  |  | 951 | 38afe12ecb0a70b3a10878d87a78d53aa9eb6cfc
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_system_readme_entry.md | 644 |  |  | 883 | 91619766996693dd2062b7c94fca0d7311d95f6c
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_system_readme_header.md | 644 |  |  | 784 | 1176db092ea100dc91c8f4e462ffad3f52761ab7
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | write_table_footer.md | 644 |  |  | 743 | b3a0f1f15970a0ce878b1fded0380ed24dc75129
+f | docs/shdoc/bin/shinclude/functions | docs/shdoc/bin/shinclude/functions | zero_pad.md | 644 |  |  | 1037 | d47d3aa0e9a1dcb4c0b4e5011db2cc008c3a2729
+f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | config_lib.sh.md | 644 |  |  | 1888 | 73777be8b37387548a83fb45ec4458ad126750e4
+f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | errno_lib.sh.md | 644 |  |  | 1045 | f09bad9e71d59b26cfe37d1d7d356009add8bf66
+f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | helpsys_lib.sh.md | 644 |  |  | 1251 | 97d7250af3a35e9a62978da087cef656c08aee27
+f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | init_lib.sh.md | 644 |  |  | 1730 | 5bb79ddaad04acf9a89c49e6d437ee96f2b12c8f
+f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | string_lib.sh.md | 644 |  |  | 859 | 4df3e8c0809e28360648f806164af7483c03566c
+f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | type_lib.sh.md | 644 |  |  | 901 | d92ef7c7084223799386c7ccd96617ef16ac5a77
+f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | util_lib.sh.md | 644 |  |  | 1411 | 818230b6cdc634f80ad49839cd190ea9171e9195
+f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | venv_lib.sh.md | 644 |  |  | 2903 | 10141e0aa2650eb815fb98ed6371e1b4e215e129
+f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | venvutil_lib.sh.md | 644 |  |  | 2031 | a131327ad602a413e921548ae137a6b2eecf93fb
+f | docs/shdoc/bin/shinclude/scripts | docs/shdoc/bin/shinclude/scripts | wrapper_lib.sh.md | 644 |  |  | 1325 | dd920e5f60e1d2208a20fd69f76b97846b938ada
 f | modules | modules | conda-install.sh | 644 |  |  | 1494 | b9d60252174be34023013a06897184db09e68664
 f | modules | modules | requirements-stdt.txt | 644 |  |  | 111 | c6028ad42de40f540c1310a09634bfb3a3a5326c
 l | bin | chunkfile.py | chunkfile | 755 |  |  | 12 | 

--- a/setup/setup.cf
+++ b/setup/setup.cf
@@ -16,7 +16,7 @@ include_dirs=("bin" "docs" "conf" "modules")
 # Package metadata
 Name: venvutil
 Description: "${TERM} Virtual Environment Utilities"
-Version: 1.0.6
+Version: 1.0.7
 Repository: https://github.com/unixwzrd/venvutil
 License: Apache License, Version 2.0
 Support: https://github.com/unixwzrd/venvutil/issues

--- a/setup/setuplib/helpsys_lib.sh
+++ b/setup/setuplib/helpsys_lib.sh
@@ -72,18 +72,15 @@ declare -g -a __VENV_INTERNAL_FUNCTIONS=(
     "docs_base_path"
     "function_description"
     "general_help"
-    "general_help"
     "generate_markdown"
     "get_script_readme_file"
     "get_system_readme_file"
     "help_functions"
-    "init_help_system"
+    "__helpsys_parse_options"
     "init_help_system"
     "process_scripts"
     "script_description"
     "specific_function_help"
-    "specific_function_help"
-    "specific_script_help"
     "specific_script_help"
     "write_function_doc"
     "write_page_footer"
@@ -929,6 +926,92 @@ help_functions() {
 
 }
 
+# # Function: __helpsys_parse_options
+#  `__helpsys_parse_options` - Parse common help/debug options.
+# ## Description
+# - **Purpose**:
+#   - Handles common function options consistently across sourced shell libraries.
+#   - Supports `-h`, `--help`, and `-x`, while allowing callers to process additional
+#     options through an optional callback.
+# - **Usage**:
+#   - `__helpsys_parse_options <optstring> [option_handler] "$@"`
+# - **Scope**:
+#   - Internal
+# - **Input Parameters**:
+#   - `optstring`: The `getopts` option string for the caller.
+#   - `option_handler`: Optional callback for caller-specific options.
+#   - `"$@"`: The caller's original argument list.
+# - **Output**:
+#   - Sets `__helpsys_optind` to the parsed `OPTIND` value.
+#   - Sets `__helpsys_help_requested=true` when help was displayed.
+#   - Sets caller-scoped `set_here=y` when `-x` is used.
+# - **Exceptions**:
+#   - Returns non-zero for invalid options or option-handler failures.
+#
+__helpsys_parse_options() {
+    local optstring="$1"; shift
+    local option_handler="${1:-}"; shift
+    local parse_optstring="${optstring#:}"
+    local opt
+    local OPTIND=1
+    local OPTERR=0
+    local func_name="${FUNCNAME[1]}"
+
+    __helpsys_help_requested=false
+    __helpsys_optind=1
+
+    while getopts ":${parse_optstring}-:" opt "$@"; do
+        case "${opt}" in
+            h)
+                vhelp "${func_name}"
+                __helpsys_help_requested=true
+                __helpsys_optind="${OPTIND}"
+                return 0
+                ;;
+            x)
+                set -x
+                # shellcheck disable=SC2034
+                set_here="y"
+                ;;
+            -)
+                case "${OPTARG}" in
+                    help)
+                        vhelp "${func_name}"
+                        __helpsys_help_requested=true
+                        __helpsys_optind="${OPTIND}"
+                        return 0
+                        ;;
+                    *)
+                        echo "Invalid option: --${OPTARG}" >&2
+                        vhelp "${func_name}"
+                        return 1
+                        ;;
+                esac
+                ;;
+            \?)
+                echo "Invalid option: -${OPTARG}" >&2
+                vhelp "${func_name}"
+                return 1
+                ;;
+            :)
+                echo "Option -${OPTARG} requires an argument." >&2
+                vhelp "${func_name}"
+                return 1
+                ;;
+            *)
+                if [[ -z "${option_handler}" ]] || ! "${option_handler}" "${opt}" "${OPTARG:-}"; then
+                    echo "Invalid option: -${opt}" >&2
+                    vhelp "${func_name}"
+                    return 1
+                fi
+                ;;
+        esac
+    done
+
+    __helpsys_optind="${OPTIND}"
+    return 0
+}
+
 # # Function: vhelp
 #  `vhelp` - Main entry point for the help system.
 # ## Description
@@ -959,7 +1042,7 @@ vhelp() {
     command -v "${MD_PROCESSOR}" > /dev/null 2>&1 && md_command="${MD_PROCESSOR}" || md_command="cat"
 
     # Check if the subcommand is a known script name
-    if [[ -n "${__VENV_SCRIPTS["${subcommand}"]:-""}" ]]; then
+    if [[ -n "${subcommand}" && -n "${__VENV_SCRIPTS["${subcommand}"]:-""}" ]]; then
         is_script=1
     fi
 

--- a/setup/setuplib/venv_lib.sh
+++ b/setup/setuplib/venv_lib.sh
@@ -101,10 +101,29 @@ __VENV_INTERNAL_FUNCTIONS=(
     "push_venv"
     "pop_venv"
     "__set_venv_vars"
+    "__lenv_parse_option"
+    "__vpmg_parse_option"
 )
 
 # Initialize the stack
 declare -ga __VENV_STACK=()
+
+__lenv_parse_option() {
+    case "$1" in
+        t) sort_by_time=true ;;
+        r) sort_opts="-r" ;;
+        l) time_opts="."; sort_key="3"; date_spacing="20" ;;
+        *) return 1 ;;
+    esac
+}
+
+__vpmg_parse_option() {
+    case "$1" in
+        v) version="$2" ;;
+        p) preserve=1 ;;
+        *) return 1 ;;
+    esac
+}
 
 
 # # Function: push_venv
@@ -294,16 +313,10 @@ vdsc() {
 #   - Errors if the environment does not exist.
 #
 cact() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local new_env="$1"
 
@@ -359,16 +372,10 @@ cact() {
 #   - None
 #
 dact() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local stack_value
 
@@ -418,17 +425,10 @@ dact() {
 #   - Errors if no previous environment exists.
 #
 pact() {
-    local OPTIND=1
-
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     pop_venv
     local previous_env="${__sv__}"
@@ -480,20 +480,10 @@ lenv() {
     local time_opts=" "
     local sort_key="3"
     local date_spacing="11"
-    local OPTIND=1
-
-    # Parse options
-    while getopts "ltrhx" opt; do
-        case $opt in
-            t) sort_by_time=true ;;
-            r) sort_opts="-r" ;;
-            l) time_opts="."; sort_key="3"; date_spacing="20";;
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "ltrhx" "__lenv_parse_option" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     # Get environment info excluding comments
     local envs_info
@@ -618,16 +608,10 @@ lastenv() {
 #   - Errors during environment creation are handled by conda.
 #
 benv() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     # Check for environment name
     if [ -z "$1" ]; then
@@ -679,19 +663,12 @@ benv() {
 #   - Errors during environment creation are handled by conda.
 #
 nenv() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local prefix="$1"; shift
-    local extra_options="$*"
 
     [ -z "${prefix}" ] && {
         echo "Error: Prefix is required." >&2
@@ -729,16 +706,10 @@ nenv() {
 #   - Errors if the environment does not exist.
 #
 denv() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local env_to_delete="$1"
 
@@ -774,16 +745,10 @@ denv() {
 #   - Errors during deactivation or deletion are handled by conda.
 #
 renv() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local env_to_delete=${CONDA_DEFAULT_ENV}
     local previous_env=${__VENV_PREV}
@@ -829,16 +794,10 @@ renv() {
 #   - Errors if the source environment does not exist.
 #
 ccln() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     # Check if current environment exists
     if [ -z "${CONDA_DEFAULT_ENV}" ]; then
@@ -900,16 +859,10 @@ ccln() {
 #   - Errors if the environment does not exist.
 #
 vren() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     local old_name new_name
 
@@ -973,6 +926,90 @@ vren() {
     return ${__rc__}
 }
 
+# # Function: vpmg
+# `vpmg` - Migrate the active virtual environment to a different Python version.
+#
+# ## Description
+# - **Purpose**:
+#   - Rebuilds the currently active conda virtual environment with a requested Python version.
+#   - Captures the installed pip package names, renames the current environment to a backup name,
+#     recreates the original environment with the requested Python version, and reinstalls the
+#     captured packages into the rebuilt environment.
+#   - By default, removes the backup environment after the migration succeeds.
+# - **Usage**:
+#   - `vpmg -v VERSION [-p]`
+# - **Options**:
+#   - `-v VERSION`  Python version to install in the rebuilt environment, such as `3.12`.
+#   - `-p`          Preserve the backup environment after a successful migration.
+#   - `-h`          Show this help message.
+#   - `-x`          Enable debug mode.
+# - **Input Parameters**:
+#   - None. The command operates on the currently active conda environment.
+# - **Output**:
+#   - Recreates the active environment with the requested Python version and reinstalls pip packages.
+#   - Creates a temporary backup environment named `<current_env>_bak` during the migration.
+# - **Exceptions**:
+#   - Returns `EINVAL` if no conda environment is active or no Python version is supplied.
+#   - Restores the backup environment name if environment creation or package installation fails.
+#
+vpmg() {
+    local version=""
+    local preserve=0
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hv:px" "__vpmg_parse_option" "$@" || return "$(errno_warn $?)"
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
+
+    [[ -n "${CONDA_DEFAULT_ENV:-}" ]] || return "$(errno_warn 22)"
+    [[ -n "$version" ]] || return "$(errno_warn 22)"
+
+    local orig_env="${CONDA_DEFAULT_ENV}"
+    local backup_env="${orig_env}_bak"
+    local freeze_file pkgs
+
+    # Capture package names BEFORE we switch envs.
+    # - Drop first 2 header lines, take col 1
+    # mapfile -t pkgs < <(pip list | sed -n '3,${s/[[:space:]].*//;p;}')
+    freeze_file="${VENVUTIL_CONFIG}/freeze/${CONDA_DEFAULT_ENV}.current.txt"
+
+
+freeze_file="${VENVUTIL_CONFIG}/freeze/${CONDA_DEFAULT_ENV}.current.txt"
+
+    mapfile -t pkgs < <(
+        sed -E '
+            s/^([^ ]+) @ (git\+[^ ]+)/\2/;   # pkg @ git+... → git+...
+            s/@[a-f0-9]{40}//;              # strip commit hashes
+            s/==.*$//;                      # remove version pins
+        ' "$freeze_file"
+    )
+
+    # Rename current env out of the way (vren activates backup env)
+    vren "$backup_env" || return "$(errno_warn $?)"
+
+    # Create the new env with requested Python (benv activates orig_env)
+    benv "$orig_env" "python=${version}" || {
+        __rc__=$?
+        vren "$orig_env" >/dev/null 2>&1
+        return "$(errno_warn ${__rc__})"
+    }
+
+    # Install prior packages into the new env
+    # (single command, logged by your wrapper)
+    echo "pip install ${pkgs[@]}"
+    pip install ${pkgs[@]} || {
+        __rc__=$?
+        cact "${backup_env}"
+        denv "${orig_env}"
+        vren "$orig_env" >/dev/null 2>&1
+        return "$(errno_warn ${__rc__})"
+    }
+
+    (( preserve )) && return 0
+    denv "$backup_env" || return "$(errno_warn $?)"
+
+    return "${__rc__}"
+}
+
 # # Function: venvdiff
 # `venvdiff` - Compare Two Virtual Environments.
 #
@@ -993,16 +1030,10 @@ vren() {
 #   - Errors if either environment does not exist.
 #
 vdiff() {
-    local OPTIND=1
-    # Parse options
-    while getopts "hx" opt; do
-        case $opt in
-            h) vhelp "${FUNCNAME[0]}"; return 0 ;;
-            x) set -x; local set_here="y" ;;
-            \?) echo "Invalid option: -$OPTARG" >&2; vhelp "${FUNCNAME[0]}"; return 1 ;;
-        esac
-    done
-    shift $((OPTIND - 1))
+    local set_here="" __helpsys_help_requested=false __helpsys_optind=1
+    __helpsys_parse_options "hx" "" "$@" || return $?
+    "${__helpsys_help_requested}" && return 0
+    shift "$((__helpsys_optind - 1))"
 
     # Check that two arguments are provided
     if [ "$#" -ne 2 ]; then


### PR DESCRIPTION
- Added a shared `__helpsys_parse_options` helper in [`bin/shinclude/helpsys_lib.sh`](bin/shinclude/helpsys_lib.sh) for consistent `-h`, `--help`, and `-x` handling across sourced shell functions.
- Refactored [`bin/shinclude/venv_lib.sh`](bin/shinclude/venv_lib.sh) option parsing to use the shared helper, with internal callbacks for function-specific options such as `lenv` sorting flags and `vpmg` version/preserve flags.
- Fixed a bug where `vhelp  would complain about ``` bash: __VENV_SCRIPTS: bad array subscript ```
- Even though it's not "ofically " part of this, made an enhancement to `mympy-comp` so it woudl pick up the correct Xcode `/usr/include` and `/usr/lib` when recompiling numpy.
- new functio/command `vpmg` migrates a pythin venv to a new version of Python.